### PR TITLE
feature: try-catch camel eip step extension

### DIFF
--- a/try-catch-finally-eip.yaml
+++ b/try-catch-finally-eip.yaml
@@ -1,0 +1,11 @@
+name: Config
+id: step-extension-do-try-eip
+type: step
+url: http://localhost:3002/remoteEntry.js
+scope: 'stepextensiondotryeip'
+module: './DoCatch'
+constraints: 
+   -
+      mandatory: true
+      operation: CONTAINS_STEP_NAME
+      parameter: do-try


### PR DESCRIPTION
When https://github.com/KaotoIO/step-extension-repository/pull/12 is merged, we will need this to use the extension in Kaoto.